### PR TITLE
Issue番号指定時の親切なエラーメッセージ機能を追加

### DIFF
--- a/src/make_rule/bulk_review_comments_fetcher.py
+++ b/src/make_rule/bulk_review_comments_fetcher.py
@@ -156,7 +156,11 @@ class BulkReviewCommentsFetcher:
                 f.write("|-----------|--------------|----------|\n")
                 for row in rows:
                     # Markdownテーブル用にパイプをエスケープ
-                    comment_body = (row["comment_body"] or "").replace("|", "\\|").replace("\n", "<br>")
+                    comment_body = (
+                        (row["comment_body"] or "")
+                        .replace("|", "\\|")
+                        .replace("\n", "<br>")
+                    )
                     file_path = (row["file_path"] or "").replace("|", "\\|")
                     f.write(f"| {row['pr_number']} | {comment_body} | {file_path} |\n")
             print(f"\nData exported to {filename}")

--- a/src/make_rule/github_review_comments_fetcher.py
+++ b/src/make_rule/github_review_comments_fetcher.py
@@ -152,12 +152,12 @@ class GitHubReviewCommentsFetcher:
         """
         url = f"{self.base_url}/repos/{owner}/{repo}/issues/{number}"
         response = requests.get(url, headers=self.headers)
-        
+
         if response.status_code == 200:
             issue_data = response.json()
             # pull_requestフィールドがない場合はissue
             return "pull_request" not in issue_data
-        
+
         return False
 
     def get_pull_request_info(
@@ -182,7 +182,9 @@ class GitHubReviewCommentsFetcher:
             # 404エラーの場合、issueかどうかチェック
             if response.status_code == 404:
                 if self.check_if_issue(owner, repo, pr_number):
-                    print(f"Note: #{pr_number} is an issue, not a pull request. Skipping...")
+                    print(
+                        f"Note: #{pr_number} is an issue, not a pull request. Skipping..."
+                    )
                     print("This tool is designed to fetch pull request comments only.")
                     return None
                 else:

--- a/src/make_rule/github_review_comments_fetcher.py
+++ b/src/make_rule/github_review_comments_fetcher.py
@@ -138,6 +138,28 @@ class GitHubReviewCommentsFetcher:
 
         return comments
 
+    def check_if_issue(self, owner: str, repo: str, number: int) -> bool:
+        """
+        指定された番号がissueかどうかをチェック
+
+        Args:
+            owner: リポジトリオーナー
+            repo: リポジトリ名
+            number: チェックする番号
+
+        Returns:
+            issueの場合True、そうでなければFalse
+        """
+        url = f"{self.base_url}/repos/{owner}/{repo}/issues/{number}"
+        response = requests.get(url, headers=self.headers)
+        
+        if response.status_code == 200:
+            issue_data = response.json()
+            # pull_requestフィールドがない場合はissue
+            return "pull_request" not in issue_data
+        
+        return False
+
     def get_pull_request_info(
         self, owner: str, repo: str, pr_number: int
     ) -> Optional[Dict]:
@@ -157,9 +179,19 @@ class GitHubReviewCommentsFetcher:
         response = requests.get(url, headers=self.headers)
 
         if response.status_code != 200:
-            print(f"Error fetching PR info: {response.status_code}")
-            print(response.json())
-            return None
+            # 404エラーの場合、issueかどうかチェック
+            if response.status_code == 404:
+                if self.check_if_issue(owner, repo, pr_number):
+                    print(f"Note: #{pr_number} is an issue, not a pull request. Skipping...")
+                    print("This tool is designed to fetch pull request comments only.")
+                    return None
+                else:
+                    print(f"Error: Pull request #{pr_number} not found.")
+                    return None
+            else:
+                print(f"Error fetching PR info: {response.status_code}")
+                print(response.json())
+                return None
 
         return response.json()
 

--- a/src/tests/unit/test_bulk_review_comments_fetcher.py
+++ b/src/tests/unit/test_bulk_review_comments_fetcher.py
@@ -478,7 +478,9 @@ class TestBulkReviewCommentsFetcher:
             assert "| PR Number | Comment Body | File Path |" in content
             assert "|-----------|--------------|----------|" in content
             assert "| 123 | Test comment | test.py |" in content
-            assert "| 123 | Comment with \\| pipe and<br>multiline | test2.py |" in content
+            assert (
+                "| 123 | Comment with \\| pipe and<br>multiline | test2.py |" in content
+            )
         finally:
             if os.path.exists(temp_filename):
                 os.unlink(temp_filename)
@@ -530,8 +532,8 @@ class TestBulkReviewCommentsFetcher:
                 content = f.read()
 
             # Should only have 1 data row (None comment skipped)
-            lines = content.strip().split('\n')
-            data_lines = [line for line in lines if line.startswith('| 123')]
+            lines = content.strip().split("\n")
+            data_lines = [line for line in lines if line.startswith("| 123")]
             assert len(data_lines) == 1
             assert "Valid comment" in content
 
@@ -562,7 +564,9 @@ class TestBulkReviewCommentsFetcher:
             assert "No data to export" in captured.out
 
             # File should not be created or should be empty
-            assert not os.path.exists(temp_filename) or os.path.getsize(temp_filename) == 0
+            assert (
+                not os.path.exists(temp_filename) or os.path.getsize(temp_filename) == 0
+            )
 
         finally:
             if os.path.exists(temp_filename):

--- a/src/tests/unit/test_github_review_comments_fetcher.py
+++ b/src/tests/unit/test_github_review_comments_fetcher.py
@@ -94,7 +94,9 @@ class TestGitHubReviewCommentsFetcher:
         assert result is None
         captured = capsys.readouterr()
         assert "Note: #123 is an issue, not a pull request. Skipping..." in captured.out
-        assert "This tool is designed to fetch pull request comments only." in captured.out
+        assert (
+            "This tool is designed to fetch pull request comments only." in captured.out
+        )
 
     @responses.activate
     def test_check_if_issue_true(self, mock_github_token):
@@ -130,7 +132,7 @@ class TestGitHubReviewCommentsFetcher:
                 "state": "open",
                 "pull_request": {  # This field indicates it's a PR
                     "url": "https://api.github.com/repos/test_owner/test_repo/pulls/123"
-                }
+                },
             },
             status=200,
         )


### PR DESCRIPTION
## Summary
- PR番号として指定された番号がissueの場合に親切なメッセージを表示する機能を追加
- 従来の404エラーの代わりに、「これはissueなのでスキップします」というメッセージを表示
- GitHub APIの`/issues`エンドポイントを使用してissue判定を実装

## 変更内容
- `check_if_issue()` メソッドを追加: 指定番号がissueかどうかを判定
- `get_pull_request_info()` メソッドを更新: 404エラー時にissueチェックを実行
- 親切なエラーメッセージを表示: "Note: #XXX is an issue, not a pull request. Skipping..."
- 包括的なテストケースを追加: issue判定とエラーハンドリングのテスト

## Test plan
- [x] 既存テストがすべて通過することを確認
- [x] 新しいissue判定機能のテストを追加
- [x] エラーメッセージの表示内容を検証
- [x] コード品質チェックを実行

🤖 Generated with [Claude Code](https://claude.ai/code)